### PR TITLE
🧹 [code health improvement] Remove unused tw-animate-css dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,6 @@
         "sonner": "^2.0.7",
         "swr": "^2.4.1",
         "tailwind-merge": "^3.5.0",
-        "tw-animate-css": "^1.4.0",
         "zustand": "^5.0.11"
       },
       "devDependencies": {
@@ -8804,15 +8803,6 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.8.1.tgz",
       "integrity": "sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==",
       "license": "0BSD"
-    },
-    "node_modules/tw-animate-css": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/tw-animate-css/-/tw-animate-css-1.4.0.tgz",
-      "integrity": "sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==",
-      "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/Wombosvideo"
-      }
     },
     "node_modules/type-check": {
       "version": "0.4.0",

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "sonner": "^2.0.7",
     "swr": "^2.4.1",
     "tailwind-merge": "^3.5.0",
-    "tw-animate-css": "^1.4.0",
     "zustand": "^5.0.11"
   },
   "devDependencies": {


### PR DESCRIPTION
🎯 **What:** Removed the unused `tw-animate-css` dependency from `package.json` and updated `package-lock.json`.

💡 **Why:** `tw-animate-css` was listed in the dependencies but is not used anywhere in the codebase. Removing unused dependencies reduces the package size, speeds up installation, avoids potential unneeded security risks, and improves overall project maintainability and cleanliness.

✅ **Verification:**
- Verified via `grep -r "tw-animate-css" . --exclude-dir=node_modules --exclude-dir=.next --exclude-dir=.git` that the dependency is not used in the codebase.
- Removed from `package.json` and ran `npm install --package-lock-only` to sync lockfile.
- Ran `npm run lint` successfully without warnings.
- Ran `npm run build` successfully to ensure the application still compiles.

✨ **Result:** A cleaner `package.json` and lockfile without breaking any existing functionality.

---
*PR created automatically by Jules for task [12889106105111820325](https://jules.google.com/task/12889106105111820325) started by @parvezk*