### PR TITLE
🧹 [remove unused lucide-react dependency]

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,7 +11,6 @@
         "@base-ui/react": "^1.2.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
-        "lucide-react": "^0.577.0",
         "nanoid": "^5.1.6",
         "next": "14.2.5",
         "react": "^18",
@@ -6028,15 +6027,6 @@
       "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
       "dev": true,
       "license": "ISC"
-    },
-    "node_modules/lucide-react": {
-      "version": "0.577.0",
-      "resolved": "https://registry.npmjs.org/lucide-react/-/lucide-react-0.577.0.tgz",
-      "integrity": "sha512-4LjoFv2eEPwYDPg/CUdBJQSDfPyzXCRrVW1X7jrx/trgxnxkHFjnVZINbzvzxjN70dxychOfg+FTYwBiS3pQ5A==",
-      "license": "ISC",
-      "peerDependencies": {
-        "react": "^16.5.1 || ^17.0.0 || ^18.0.0 || ^19.0.0"
-      }
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",

--- a/package.json
+++ b/package.json
@@ -12,7 +12,6 @@
     "@base-ui/react": "^1.2.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
-    "lucide-react": "^0.577.0",
     "nanoid": "^5.1.6",
     "next": "14.2.5",
     "react": "^18",


### PR DESCRIPTION
🎯 **What:** Removed the unused `lucide-react` dependency from `package.json` and `package-lock.json`.
💡 **Why:** Reduces unnecessary dependencies, streamlining project footprint and mitigating potential future vulnerabilities while keeping the codebase cleaner and easier to maintain.
✅ **Verification:** Validated that `lucide-react` does not exist in any file other than `package.json` and `package-lock.json`. Re-ran `npm install --package-lock-only`, followed by `npm run lint` and `npm run build`, to ensure no functionality is broken and lockfiles were updated cleanly. 
✨ **Result:** A lighter project configuration that builds successfully with zero side effects.

---
*PR created automatically by Jules for task [18443745147692655379](https://jules.google.com/task/18443745147692655379) started by @parvezk*