### PR TITLE
fix: fetch stock data on ticker input blur

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -324,6 +324,23 @@ export default function Home() {
     [fetchPrice],
   );
 
+  const handleTickerBlur = useCallback(
+    (positionId: string, ticker: string) => {
+      const cleanedTicker = ticker.trim().toUpperCase();
+      if (!cleanedTicker) return;
+
+      const position = useTrancheStore
+        .getState()
+        .positions.find((p) => p.id === positionId);
+      if (!position) return;
+
+      if (position.price === null && !position.loading && !position.error) {
+        void fetchPrice(positionId, ticker);
+      }
+    },
+    [fetchPrice],
+  );
+
   const handlePositionMouseEnter = useCallback(
     (position: Position) => {
       if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
@@ -513,6 +530,7 @@ export default function Home() {
                     placeholder="TICK"
                     onChange={(event) => handleTickerChange(position.id, event.target.value)}
                     onKeyDown={(event) => handleTickerKeyDown(event, position.id, position.ticker)}
+                    onBlur={() => handleTickerBlur(position.id, position.ticker)}
                     className="h-9 border-[#27272a] bg-[#09090b] px-2 text-center text-base font-semibold uppercase text-[#f59e0b] [font-family:var(--font-mono)] placeholder:text-[#3f3f46]"
                   />
 


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Problem

When a user types a ticker symbol (e.g., "SOXX") and then moves focus away from the input (by clicking elsewhere like the shares +/- buttons), the stock data (name, price, total) never loads. Data was only fetched when the user explicitly pressed Enter or Tab.

**Resolves:** PK-247

## Solution

Added an `onBlur` handler (`handleTickerBlur`) to the ticker input that triggers the price fetch when the input loses focus. The handler includes guards to avoid redundant fetches:

- Skips if the ticker is empty
- Skips if the position already has a price loaded (e.g., Enter/Tab was already used)
- Skips if a fetch is already in progress (`loading === true`)
- Skips if there's already an error (avoids re-fetching known-invalid tickers on every blur)

This ensures that simply typing a valid ticker and clicking away will automatically validate and populate the row with stock data.

## Changes

- `app/page.tsx`: Added `handleTickerBlur` callback and wired it to the ticker `Input`'s `onBlur` prop
<!-- CURSOR_AGENT_PR_BODY_END -->

Linear Issue: [PK-247](https://linear.app/pk-hq/issue/PK-247/the-stock-ticker-doesnt-populate-until-i-hit-the-enter-key-usually-if)

<div><a href="https://cursor.com/agents/bc-5eef6ba8-1c34-4167-b50a-2d837d20a86b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5eef6ba8-1c34-4167-b50a-2d837d20a86b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

