### PR TITLE
🔒 Disable deprecated X-XSS-Protection header

### DIFF
--- a/next.config.mjs
+++ b/next.config.mjs
@@ -11,7 +11,7 @@ const nextConfig = {
           },
           {
             key: 'X-XSS-Protection',
-            value: '1; mode=block'
+            value: '0'
           },
           {
             key: 'X-Frame-Options',


### PR DESCRIPTION
🎯 What
This pull request disables the deprecated `X-XSS-Protection` header by changing its value from `1; mode=block` to `0` in `next.config.mjs`.

⚠️ Risk
The `X-XSS-Protection` header (specifically the `1; mode=block` directive) is deprecated in modern browsers. It relies on the browser's built-in XSS Auditor, which has known flaws and can sometimes be abused by attackers to create new cross-site scripting vulnerabilities or side-channel attacks by maliciously triggering the block mechanism against legitimate scripts.

🛡️ Solution
The recommended security best practice is to set the `X-XSS-Protection` header to `0` to explicitly disable the legacy XSS Auditor, and rely on stronger, modern protections such as Content Security Policy (CSP).

---
*PR created automatically by Jules for task [5630891381268300577](https://jules.google.com/task/5630891381268300577) started by @parvezk*