### PR TITLE
Remove Zustand rationale from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,11 +33,3 @@ npm run dev
 ```
 
 Open `http://localhost:3000`.
-
-## Why Zustand here?
-
-This app could be built with React Context + reducer, but Zustand is used for:
-
-- Simpler global state with fewer provider wrappers.
-- Built-in persistence middleware for the `tranche-session` localStorage key.
-- Easier selective subscriptions as the table grows, reducing unnecessary rerenders.


### PR DESCRIPTION
### Motivation
- Remove the "Why Zustand here?" rationale from `README.md` to streamline the documentation and reduce redundant justification in the repository.

### Description
- Deleted the `Why Zustand here?` section and its bullet points from `README.md` while keeping the rest of the README content unchanged.

### Testing
- This is a documentation-only change so no automated tests were run and no code behavior was modified.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9273d6b308331ab44493a69ee17c0)