### PR TITLE
Add Clear Allocations / Clear all actions and store handlers

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -120,6 +120,8 @@ export default function Home() {
     setError,
     setPerf,
     resetMarketData,
+    clearAllocations,
+    clearEverything,
     replaceFromShareState,
   } = useTrancheStore();
 
@@ -400,6 +402,23 @@ export default function Home() {
     [setShares],
   );
 
+  const resetTransientUi = useCallback(() => {
+    setPerfLoadingMap({});
+    setActivePopoverId(null);
+  }, []);
+
+  const handleClearAllocations = useCallback(() => {
+    clearAllocations();
+    resetTransientUi();
+    toast.success("All allocations cleared");
+  }, [clearAllocations, resetTransientUi]);
+
+  const handleClearEverything = useCallback(() => {
+    clearEverything();
+    resetTransientUi();
+    toast.success("Everything is cleared");
+  }, [clearEverything, resetTransientUi]);
+
   const copyShareLink = useCallback(async () => {
     const url = new URL(window.location.href);
     url.searchParams.set("b", String(Number(budget.toFixed(2))));
@@ -471,6 +490,24 @@ export default function Home() {
                 >
                   {currency.format(remaining)}
                 </p>
+              </div>
+              <div className="col-span-2 mt-0.5 flex w-full gap-2 sm:col-span-1 sm:w-auto">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleClearAllocations}
+                  className="flex-1 border-[#27272a] bg-transparent text-[#e4e4e7] hover:bg-[#202024]"
+                >
+                  Clear Allocations
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={handleClearEverything}
+                  className="flex-1 border-[#27272a] bg-transparent text-[#e4e4e7] hover:bg-[#202024]"
+                >
+                  Clear all
+                </Button>
               </div>
               <Button
                 variant="outline"

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -43,6 +43,8 @@ interface Store {
   setError: (id: string, error: string | null) => void;
   setPerf: (id: string, perf: PositionPerf) => void;
   resetMarketData: () => void;
+  clearAllocations: () => void;
+  clearEverything: () => void;
   replaceFromShareState: (budget: number | null, positions: ReplacePositionInput[]) => void;
 }
 
@@ -167,6 +169,15 @@ export const useTrancheStore = create<Store>()(
             loading: false,
             error: null,
           })),
+        })),
+      clearAllocations: () =>
+        set(() => ({
+          positions: [createEmptyPosition()],
+        })),
+      clearEverything: () =>
+        set(() => ({
+          budget: 0,
+          positions: [createEmptyPosition()],
         })),
       replaceFromShareState: (budget, positions) =>
         set(() => ({


### PR DESCRIPTION
### Motivation
- Provide quick actions to reset allocations or wipe all saved data so users can start fresh without manually clearing each row.
- Ensure transient UI state is reset when performing these global clears to avoid stale UI artifacts.

### Description
- Added `clearAllocations` and `clearEverything` to the store to reset positions to a single empty row and to reset budget+positions respectively.
- Added UI buttons `Clear Allocations` and `Clear all` in the header and wired them to `handleClearAllocations` and `handleClearEverything` handlers. 
- Implemented `resetTransientUi` to clear `perfLoadingMap` and `activePopoverId` when performing clears, and show success toasts after each action.
- Kept existing persistence shape (partialize still persists `budget` and `positions`) and reused `createEmptyPosition` for consistent initial row creation.

### Testing
- Ran TypeScript check with `tsc --noEmit`, which succeeded. 
- Built the app with `next build`, which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_69f9284b08c88331b244475ddfdf4a6d)