### PR TITLE
Add market strip, fractional share editing, and reset safeguards

### DIFF
--- a/app/api/market-strip/route.ts
+++ b/app/api/market-strip/route.ts
@@ -1,12 +1,8 @@
 import { fetchYahooChartResult } from "@/lib/server/yahoo";
 import { isNumber } from "@/lib/utils";
+import { type MarketDefinition, type MarketQuote } from "@/lib/utils/market-strip";
 
 export const dynamic = "force-dynamic";
-
-interface MarketDefinition {
-  symbol: string;
-  label: string;
-}
 
 interface MarketMeta {
   regularMarketPrice?: number;
@@ -33,7 +29,8 @@ const ETFS: MarketDefinition[] = [
   { symbol: "EEM", label: "EEM" },
 ];
 
-async function fetchMarketQuote(definition: MarketDefinition) {
+// Normalize a Yahoo chart response into the compact quote shape consumed by the header strip.
+async function fetchMarketQuote(definition: MarketDefinition): Promise<MarketQuote> {
   const result = await fetchYahooChartResult(definition.symbol, { interval: "1d", range: "1d" });
   const meta = (result?.meta as MarketMeta | undefined) ?? null;
   const price = meta?.regularMarketPrice;
@@ -51,11 +48,15 @@ async function fetchMarketQuote(definition: MarketDefinition) {
   };
 }
 
+async function fetchQuoteGroup(definitions: MarketDefinition[]) {
+  return Promise.all(definitions.map(fetchMarketQuote));
+}
+
+// Serves both index and ETF quote groups in one request so the client can toggle instantly.
 export async function GET() {
-  const [indexes, etfs] = await Promise.all([
-    Promise.all(INDEXES.map(fetchMarketQuote)),
-    Promise.all(ETFS.map(fetchMarketQuote)),
-  ]);
+  const indexesPromise = fetchQuoteGroup(INDEXES);
+  const etfsPromise = fetchQuoteGroup(ETFS);
+  const [indexes, etfs] = await Promise.all([indexesPromise, etfsPromise]);
 
   return Response.json(
     { indexes, etfs },

--- a/app/api/market-strip/route.ts
+++ b/app/api/market-strip/route.ts
@@ -1,0 +1,64 @@
+import { fetchYahooChartResult } from "@/lib/server/yahoo";
+import { isNumber } from "@/lib/utils";
+
+export const dynamic = "force-dynamic";
+
+interface MarketDefinition {
+  symbol: string;
+  label: string;
+}
+
+interface MarketMeta {
+  regularMarketPrice?: number;
+  chartPreviousClose?: number;
+  previousClose?: number;
+}
+
+const INDEXES: MarketDefinition[] = [
+  { symbol: "^GSPC", label: "S&P 500" },
+  { symbol: "^IXIC", label: "Nasdaq" },
+  { symbol: "^DJI", label: "Dow Jones" },
+  { symbol: "^RUT", label: "Russell 2000" },
+  { symbol: "^990100-USD-STRD", label: "MSCI World" },
+];
+
+const ETFS: MarketDefinition[] = [
+  { symbol: "VOO", label: "VOO" },
+  { symbol: "QQQ", label: "QQQ" },
+  { symbol: "VTI", label: "VTI" },
+  { symbol: "VT", label: "VT" },
+  { symbol: "VXUS", label: "VXUS" },
+  { symbol: "VONE", label: "VONE" },
+  { symbol: "IEUR", label: "IEUR" },
+  { symbol: "EEM", label: "EEM" },
+];
+
+async function fetchMarketQuote(definition: MarketDefinition) {
+  const result = await fetchYahooChartResult(definition.symbol, { interval: "1d", range: "1d" });
+  const meta = (result?.meta as MarketMeta | undefined) ?? null;
+  const price = meta?.regularMarketPrice;
+  const previousClose = meta?.chartPreviousClose ?? meta?.previousClose;
+  const change = isNumber(price) && isNumber(previousClose) ? price - previousClose : null;
+  const changePct =
+    isNumber(change) && isNumber(previousClose) && previousClose !== 0 ? (change / previousClose) * 100 : null;
+
+  return {
+    symbol: definition.symbol,
+    label: definition.label,
+    price: isNumber(price) ? price : null,
+    change,
+    changePct,
+  };
+}
+
+export async function GET() {
+  const [indexes, etfs] = await Promise.all([
+    Promise.all(INDEXES.map(fetchMarketQuote)),
+    Promise.all(ETFS.map(fetchMarketQuote)),
+  ]);
+
+  return Response.json(
+    { indexes, etfs },
+    { headers: { "Cache-Control": "s-maxage=15, stale-while-revalidate=30" } },
+  );
+}

--- a/app/globals.css
+++ b/app/globals.css
@@ -24,6 +24,22 @@
     --input: 39 39 42;
     --ring: 245 158 11;
     --radius: 0.375rem;
+    --tranche-page: #09090b;
+    --tranche-panel: #18181b;
+    --tranche-popover: #121214;
+    --tranche-hover: #202024;
+    --tranche-border-muted: #27272a;
+    --tranche-border-strong: #3f3f46;
+    --tranche-text: #e4e4e7;
+    --tranche-muted: #a1a1aa;
+    --tranche-muted-strong: #71717a;
+    --tranche-warning: #f59e0b;
+    --tranche-warning-border: #7c5412;
+    --tranche-warning-surface: #2f230f;
+    --tranche-danger: #f87171;
+    --tranche-success: #4ade80;
+    --tranche-success-border: #14532d;
+    --tranche-success-soft: #86efac;
   }
 
   * {

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,6 +1,7 @@
 import Link from "next/link";
 
 import { getAllocationSnapshots } from "@/lib/server/allocations";
+import { formatSupabaseError } from "@/lib/server/supabase-errors";
 
 export const dynamic = "force-dynamic";
 
@@ -26,8 +27,10 @@ export default async function HistoryRoute() {
   try {
     allocations = await getAllocationSnapshots();
   } catch (caught) {
-    error = caught instanceof Error ? caught.message : "Unable to load allocation history.";
+    error = formatSupabaseError(caught, "Unable to load allocation history.");
   }
+
+  const isConfigError = error?.toLowerCase().includes("supabase is not configured") ?? false;
 
   return (
     <main className="min-h-screen overflow-x-hidden bg-[#09090b] px-3 py-6 text-[#e4e4e7] sm:px-6 sm:py-8">
@@ -61,10 +64,17 @@ export default async function HistoryRoute() {
           {error ? (
             <div className="px-4 py-6">
               <p className="text-sm text-[#f87171]">{error}</p>
-              <p className="mt-2 text-sm text-[#a1a1aa]">
-                Add the Supabase table from <code>supabase/migrations</code>, then set{" "}
-                <code>SUPABASE_URL</code> and <code>SUPABASE_SERVICE_ROLE_KEY</code> in the environment.
-              </p>
+              {isConfigError ? (
+                <p className="mt-2 text-sm text-[#a1a1aa]">
+                  Add the Supabase table from <code>supabase/migrations</code>, then set{" "}
+                  <code>SUPABASE_URL</code> and <code>SUPABASE_SERVICE_ROLE_KEY</code> in the environment.
+                </p>
+              ) : (
+                <p className="mt-2 text-sm text-[#a1a1aa]">
+                  Your saved allocations are still in Supabase. The History page will recover once the database is
+                  available again.
+                </p>
+              )}
             </div>
           ) : allocations.length === 0 ? (
             <div className="px-4 py-10 text-center text-sm text-[#a1a1aa]">

--- a/app/history/page.tsx
+++ b/app/history/page.tsx
@@ -1,7 +1,7 @@
 import Link from "next/link";
 
 import { getAllocationSnapshots } from "@/lib/server/allocations";
-import { formatSupabaseError } from "@/lib/server/supabase-errors";
+import { formatSupabaseError, isSupabaseConfigError } from "@/lib/server/supabase-errors";
 
 export const dynamic = "force-dynamic";
 
@@ -30,7 +30,7 @@ export default async function HistoryRoute() {
     error = formatSupabaseError(caught, "Unable to load allocation history.");
   }
 
-  const isConfigError = error?.toLowerCase().includes("supabase is not configured") ?? false;
+  const isConfigError = error ? isSupabaseConfigError(error) : false;
 
   return (
     <main className="min-h-screen overflow-x-hidden bg-[#09090b] px-3 py-6 text-[#e4e4e7] sm:px-6 sm:py-8">

--- a/components/tranche/allocation-page.tsx
+++ b/components/tranche/allocation-page.tsx
@@ -5,6 +5,7 @@ import Link from "next/link";
 import { toast } from "sonner";
 
 import { MarketStrip } from "@/components/tranche/market-strip";
+import { NotePopover } from "@/components/tranche/note-popover";
 import { ShareInput } from "@/components/tranche/share-input";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
@@ -774,52 +775,13 @@ export default function Home() {
                       {pctBudget.toFixed(1)}%
                     </span>
                   </div>
-                  <div className="relative flex justify-center">
-                    <Button
-                      variant="ghost"
-                      size="icon-sm"
-                      onClick={() => setActiveNoteId((current) => (current === position.id ? null : position.id))}
-                      className={`relative h-8 w-8 border ${
-                        position.notes
-                          ? "border-[#7c5412] bg-[#2f230f] text-[#f59e0b]"
-                          : "border-[#27272a] text-[#71717a]"
-                      } hover:bg-[#202024] hover:text-[#f59e0b]`}
-                      aria-label={position.notes ? "Open position note" : "Add position note"}
-                      aria-expanded={activeNoteId === position.id}
-                    >
-                      <span aria-hidden="true">✎</span>
-                      {position.notes && (
-                        <span className="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-[#f59e0b]" />
-                      )}
-                    </Button>
-                    {activeNoteId === position.id && (
-                      <div className="absolute right-0 top-10 z-30 w-64 rounded-sm border border-[#3f3f46] bg-[#121214] p-3 shadow-2xl">
-                        <div className="mb-2 flex items-center justify-between">
-                          <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-[#a1a1aa]">
-                            {position.ticker || "Position"} note
-                          </p>
-                          <button
-                            type="button"
-                            onClick={() => setActiveNoteId(null)}
-                            className="px-1 text-lg leading-none text-[#71717a] hover:text-[#e4e4e7]"
-                            aria-label="Close note"
-                          >
-                            ×
-                          </button>
-                        </div>
-                        <textarea
-                          value={position.notes}
-                          maxLength={160}
-                          placeholder="Add note"
-                          disabled={position.locked}
-                          autoFocus={!position.locked}
-                          onChange={(event) => setNotes(position.id, event.target.value)}
-                          className="h-24 w-full resize-none rounded-sm border border-[#27272a] bg-[#09090b] px-2 py-2 text-xs leading-4 text-[#e4e4e7] outline-none placeholder:text-[#52525b] focus:border-[#f59e0b] disabled:border-[#14532d] disabled:text-[#86efac]"
-                        />
-                        <p className="mt-1 text-right text-[10px] text-[#52525b]">{position.notes.length}/160</p>
-                      </div>
-                    )}
-                  </div>
+                  <NotePopover
+                    position={position}
+                    isOpen={activeNoteId === position.id}
+                    onToggle={() => setActiveNoteId((current) => (current === position.id ? null : position.id))}
+                    onClose={() => setActiveNoteId(null)}
+                    onChange={(notes) => setNotes(position.id, notes)}
+                  />
                   <Button
                     variant="ghost"
                     size="icon-sm"
@@ -861,19 +823,19 @@ export default function Home() {
             role="dialog"
             aria-modal="true"
             aria-labelledby="reset-title"
-            className="w-full max-w-md rounded-sm border border-[#3f3f46] bg-[#18181b] p-5 shadow-2xl"
+            className="w-full max-w-md rounded-sm border border-[var(--tranche-border-strong)] bg-[var(--tranche-panel)] p-5 shadow-2xl"
           >
             <p id="reset-title" className="text-lg font-semibold text-[#f4f4f5]">
               Reset allocation?
             </p>
-            <p className="mt-2 text-sm leading-6 text-[#a1a1aa]">
+            <p className="mt-2 text-sm leading-6 text-[var(--tranche-muted)]">
               This allocation contains locked positions. Your proceeds budget will be preserved either way.
             </p>
             <div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
               <Button variant="ghost" onClick={() => setResetDialogOpen(false)}>
                 Cancel
               </Button>
-              <Button variant="outline" onClick={resetKeepingLocked} className="border-[#3f3f46]">
+              <Button variant="outline" onClick={resetKeepingLocked} className="border-[var(--tranche-border-strong)]">
                 Keep locked
               </Button>
               <Button variant="destructive" onClick={resetIncludingLocked}>

--- a/components/tranche/allocation-page.tsx
+++ b/components/tranche/allocation-page.tsx
@@ -4,6 +4,8 @@ import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
 import { toast } from "sonner";
 
+import { MarketStrip } from "@/components/tranche/market-strip";
+import { ShareInput } from "@/components/tranche/share-input";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Progress } from "@/components/ui/progress";
@@ -124,6 +126,9 @@ export default function Home() {
     setError,
     setPerf,
     resetMarketData,
+    clearAllocations,
+    clearUnlockedAllocations,
+    clearEverything,
     replaceFromShareState,
   } = useTrancheStore();
 
@@ -133,6 +138,8 @@ export default function Home() {
   const [dragOverId, setDragOverId] = useState<string | null>(null);
   const [perfLoadingMap, setPerfLoadingMap] = useState<Record<string, boolean>>({});
   const [saving, setSaving] = useState(false);
+  const [activeNoteId, setActiveNoteId] = useState<string | null>(null);
+  const [resetDialogOpen, setResetDialogOpen] = useState(false);
 
   const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -405,22 +412,28 @@ export default function Home() {
     }, 130);
   }, []);
 
-  const handleShareChange = useCallback(
-    (event: React.ChangeEvent<HTMLInputElement>, positionId: string) => {
-      const next = Number.parseFloat(event.target.value);
-      setShares(positionId, Number.isFinite(next) && next >= 0 ? next : 0);
-    },
-    [setShares],
-  );
+  const requestReset = useCallback(() => {
+    const hasLockedPositions = useTrancheStore.getState().positions.some((position) => position.locked);
+    if (hasLockedPositions) {
+      setResetDialogOpen(true);
+      return;
+    }
 
-  const incrementShares = useCallback(
-    (position: Position, event: React.MouseEvent<HTMLButtonElement>, direction: -1 | 1) => {
-      const multiplier = event.ctrlKey || event.metaKey ? 100 : event.shiftKey ? 10 : 1;
-      const nextShares = Math.max(0, position.shares + direction * multiplier);
-      setShares(position.id, nextShares);
-    },
-    [setShares],
-  );
+    clearEverything();
+    toast.success("Allocation and proceeds reset");
+  }, [clearEverything]);
+
+  const resetKeepingLocked = useCallback(() => {
+    clearUnlockedAllocations();
+    setResetDialogOpen(false);
+    toast.success("Unlocked positions cleared");
+  }, [clearUnlockedAllocations]);
+
+  const resetIncludingLocked = useCallback(() => {
+    clearAllocations();
+    setResetDialogOpen(false);
+    toast.success("All positions cleared");
+  }, [clearAllocations]);
 
   const saveAllocation = useCallback(async () => {
     setSaving(true);
@@ -536,7 +549,7 @@ export default function Home() {
               )}
             </div>
 
-            <div className="grid grid-cols-2 gap-4 sm:flex sm:items-start sm:gap-6 lg:gap-8">
+            <div className="grid grid-cols-2 gap-3 sm:flex sm:items-start sm:gap-4 lg:gap-5">
               <div className="text-right">
                 <p className="text-xs uppercase tracking-[0.16em] text-[#52525b]">Allocated</p>
                 <p
@@ -553,25 +566,36 @@ export default function Home() {
                   {currency.format(remaining)}
                 </p>
               </div>
-              <Button
-                variant="outline"
-                size="sm"
-                onClick={() => void saveAllocation()}
-                disabled={saving}
-                className="col-span-2 mt-0.5 w-full border-[#7c5412] bg-[#f59e0b] text-[#09090b] hover:bg-[#fbbf24] sm:col-span-1 sm:w-auto"
-              >
-                {saving ? "Saving..." : "Save"}
-              </Button>
+              <div className="col-span-2 flex gap-1 sm:col-span-1">
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => void saveAllocation()}
+                  disabled={saving}
+                  className="mt-0.5 flex-1 border-[#7c5412] bg-[#f59e0b] px-2.5 text-[#09090b] hover:bg-[#fbbf24] sm:flex-none"
+                >
+                  {saving ? "Saving..." : "Save"}
+                </Button>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={requestReset}
+                  className="mt-0.5 flex-1 border-[#3f3f46] bg-transparent px-2.5 text-[#f87171] hover:border-[#7f1d1d] hover:bg-[#2b1215] sm:flex-none"
+                >
+                  Reset
+                </Button>
+              </div>
               <Button
                 variant="outline"
                 size="sm"
                 onClick={() => void copyShareLink()}
-                className="col-span-2 mt-0.5 w-full border-[#27272a] bg-transparent text-[#e4e4e7] hover:bg-[#202024] sm:col-span-1 sm:w-auto"
+                className="col-span-2 mt-0.5 w-full border-[#27272a] bg-transparent px-2.5 text-[#e4e4e7] hover:bg-[#202024] sm:col-span-1 sm:w-auto"
               >
                 Share
               </Button>
             </div>
           </div>
+          <MarketStrip />
           <Progress
             value={progressValue}
             className="h-[2px] rounded-none bg-[#27272a]"
@@ -580,7 +604,7 @@ export default function Home() {
         </header>
 
         <section className="overflow-x-auto rounded-sm border border-[#1a1a1e] bg-[#18181b]">
-          <div className="grid min-w-[1040px] grid-cols-[24px_28px_92px_minmax(240px,1fr)_148px_112px_88px_190px_64px] items-center gap-2 border-b border-[#27272a] bg-[#111113] px-2 py-3 text-xs font-bold uppercase tracking-[0.12em] text-[#7d8592] sm:px-3">
+          <div className="grid min-w-[860px] grid-cols-[22px_26px_82px_minmax(190px,1fr)_130px_102px_78px_44px_44px] items-center gap-2 border-b border-[#27272a] bg-[#111113] px-2 py-3 text-[11px] font-bold uppercase tracking-[0.1em] text-[#7d8592] sm:px-3">
             <span className="text-center">#</span>
             <span className="text-center text-sm tracking-normal">✓</span>
             <span>Ticker</span>
@@ -588,8 +612,8 @@ export default function Home() {
             <span className="text-center">Shares</span>
             <span className="text-right">Total</span>
             <span className="text-center">% Budget</span>
-            <span>Notes</span>
-            <span className="text-center">Delete</span>
+            <span className="text-center">Note</span>
+            <span className="text-center">Del</span>
           </div>
 
           <div className="divide-y divide-[#1a1a1e]">
@@ -624,8 +648,8 @@ export default function Home() {
               ];
 
               return (
-                <div key={position.id} className="contents">
                 <div
+                  key={position.id}
                   draggable
                   onDragStart={(event) => {
                     event.dataTransfer.effectAllowed = "move";
@@ -638,7 +662,7 @@ export default function Home() {
                   onDragLeave={() => setDragOverId(null)}
                   onDrop={(event) => handleDrop(event, position.id)}
                   onDragEnd={() => setDragOverId(null)}
-                  className={`grid min-w-[1040px] cursor-grab grid-cols-[24px_28px_92px_minmax(240px,1fr)_148px_112px_88px_190px_64px] items-center gap-2 px-2 py-3 active:cursor-grabbing sm:px-3 ${
+                  className={`grid min-w-[860px] cursor-grab grid-cols-[22px_26px_82px_minmax(190px,1fr)_130px_102px_78px_44px_44px] items-center gap-2 px-2 py-3 active:cursor-grabbing sm:px-3 ${
                     dragOverId === position.id ? "bg-[#202024]" : position.locked ? "bg-[#111816]" : ""
                   }`}
                 >
@@ -735,35 +759,14 @@ export default function Home() {
                     )}
                   </div>
 
-                  <div className="grid grid-cols-[32px_1fr_32px] items-center gap-1">
-                    <Button
-                      variant="outline"
-                      size="icon-sm"
-                      disabled={position.locked}
-                      onClick={(event) => incrementShares(position, event, -1)}
-                      className="h-8 w-8 border-[#27272a] bg-[#09090b] text-[#e4e4e7] hover:bg-[#202024]"
-                    >
-                      -
-                    </Button>
-                    <Input
-                      ref={(node) => {
-                        shareInputRefs.current[position.id] = node;
-                      }}
-                      value={position.shares}
-                      disabled={position.locked}
-                      onChange={(event) => handleShareChange(event, position.id)}
-                      className="h-8 border-[#27272a] bg-[#09090b] px-2 text-center text-sm [font-family:var(--font-mono)] disabled:border-[#14532d] disabled:text-[#86efac]"
-                    />
-                    <Button
-                      variant="outline"
-                      size="icon-sm"
-                      disabled={position.locked}
-                      onClick={(event) => incrementShares(position, event, 1)}
-                      className="h-8 w-8 border-[#27272a] bg-[#09090b] text-[#e4e4e7] hover:bg-[#202024]"
-                    >
-                      +
-                    </Button>
-                  </div>
+                  <ShareInput
+                    value={position.shares}
+                    disabled={position.locked}
+                    inputRef={(node) => {
+                      shareInputRefs.current[position.id] = node;
+                    }}
+                    onChange={(shares) => setShares(position.id, shares)}
+                  />
 
                   <p className="text-right text-sm [font-family:var(--font-mono)]">{currency.format(total)}</p>
                   <div className="flex justify-center">
@@ -771,25 +774,62 @@ export default function Home() {
                       {pctBudget.toFixed(1)}%
                     </span>
                   </div>
-                  <textarea
-                    defaultValue={position.notes}
-                    maxLength={160}
-                    placeholder="Add note"
-                    disabled={position.locked}
-                    onBlur={(event) => setNotes(position.id, event.target.value)}
-                    className="h-12 resize-none rounded-sm border border-[#27272a] bg-[#09090b] px-2 py-1.5 text-xs leading-4 text-[#e4e4e7] outline-none placeholder:text-[#52525b] focus:border-[#f59e0b] disabled:border-[#14532d] disabled:text-[#86efac]"
-                  />
+                  <div className="relative flex justify-center">
+                    <Button
+                      variant="ghost"
+                      size="icon-sm"
+                      onClick={() => setActiveNoteId((current) => (current === position.id ? null : position.id))}
+                      className={`relative h-8 w-8 border ${
+                        position.notes
+                          ? "border-[#7c5412] bg-[#2f230f] text-[#f59e0b]"
+                          : "border-[#27272a] text-[#71717a]"
+                      } hover:bg-[#202024] hover:text-[#f59e0b]`}
+                      aria-label={position.notes ? "Open position note" : "Add position note"}
+                      aria-expanded={activeNoteId === position.id}
+                    >
+                      <span aria-hidden="true">✎</span>
+                      {position.notes && (
+                        <span className="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-[#f59e0b]" />
+                      )}
+                    </Button>
+                    {activeNoteId === position.id && (
+                      <div className="absolute right-0 top-10 z-30 w-64 rounded-sm border border-[#3f3f46] bg-[#121214] p-3 shadow-2xl">
+                        <div className="mb-2 flex items-center justify-between">
+                          <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-[#a1a1aa]">
+                            {position.ticker || "Position"} note
+                          </p>
+                          <button
+                            type="button"
+                            onClick={() => setActiveNoteId(null)}
+                            className="px-1 text-lg leading-none text-[#71717a] hover:text-[#e4e4e7]"
+                            aria-label="Close note"
+                          >
+                            ×
+                          </button>
+                        </div>
+                        <textarea
+                          value={position.notes}
+                          maxLength={160}
+                          placeholder="Add note"
+                          disabled={position.locked}
+                          autoFocus={!position.locked}
+                          onChange={(event) => setNotes(position.id, event.target.value)}
+                          className="h-24 w-full resize-none rounded-sm border border-[#27272a] bg-[#09090b] px-2 py-2 text-xs leading-4 text-[#e4e4e7] outline-none placeholder:text-[#52525b] focus:border-[#f59e0b] disabled:border-[#14532d] disabled:text-[#86efac]"
+                        />
+                        <p className="mt-1 text-right text-[10px] text-[#52525b]">{position.notes.length}/160</p>
+                      </div>
+                    )}
+                  </div>
                   <Button
                     variant="ghost"
                     size="icon-sm"
                     disabled={position.locked}
                     onClick={() => removePosition(position.id)}
-                    className="h-16 w-16 text-4xl leading-none text-[#a1a1aa] hover:bg-[#202024] hover:text-[#f87171]"
+                    className="h-8 w-8 text-2xl leading-none text-[#a1a1aa] hover:bg-[#202024] hover:text-[#f87171]"
                     aria-label="Remove position"
                   >
                     ×
                   </Button>
-                </div>
                 </div>
               );
             })}
@@ -809,6 +849,40 @@ export default function Home() {
           </div>
         </section>
       </div>
+      {resetDialogOpen && (
+        <div
+          className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 px-4"
+          role="presentation"
+          onMouseDown={(event) => {
+            if (event.target === event.currentTarget) setResetDialogOpen(false);
+          }}
+        >
+          <div
+            role="dialog"
+            aria-modal="true"
+            aria-labelledby="reset-title"
+            className="w-full max-w-md rounded-sm border border-[#3f3f46] bg-[#18181b] p-5 shadow-2xl"
+          >
+            <p id="reset-title" className="text-lg font-semibold text-[#f4f4f5]">
+              Reset allocation?
+            </p>
+            <p className="mt-2 text-sm leading-6 text-[#a1a1aa]">
+              This allocation contains locked positions. Your proceeds budget will be preserved either way.
+            </p>
+            <div className="mt-5 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end">
+              <Button variant="ghost" onClick={() => setResetDialogOpen(false)}>
+                Cancel
+              </Button>
+              <Button variant="outline" onClick={resetKeepingLocked} className="border-[#3f3f46]">
+                Keep locked
+              </Button>
+              <Button variant="destructive" onClick={resetIncludingLocked}>
+                Clear all positions
+              </Button>
+            </div>
+          </div>
+        </div>
+      )}
     </main>
   );
 }

--- a/components/tranche/market-strip.tsx
+++ b/components/tranche/market-strip.tsx
@@ -4,27 +4,21 @@ import { useCallback, useEffect, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Skeleton } from "@/components/ui/skeleton";
-
-type MarketMode = "indexes" | "etfs";
-
-interface MarketQuote {
-  symbol: string;
-  label: string;
-  price: number | null;
-  change: number | null;
-  changePct: number | null;
-}
+import {
+  formatSignedNumber,
+  getMarketMovementClass,
+  MARKET_STRIP_COLUMN_COUNTS,
+  MARKET_STRIP_LABELS,
+  type MarketMode,
+  type MarketQuote,
+} from "@/lib/utils/market-strip";
 
 const priceNumber = new Intl.NumberFormat("en-US", {
   minimumFractionDigits: 2,
   maximumFractionDigits: 2,
 });
 
-function signed(value: number | null, suffix = "") {
-  if (typeof value !== "number") return "--";
-  return `${value > 0 ? "+" : ""}${value.toFixed(2)}${suffix}`;
-}
-
+// Header ticker strip that polls the batch quote endpoint and toggles between index and ETF groups.
 export function MarketStrip() {
   const [mode, setMode] = useState<MarketMode>("indexes");
   const [quotes, setQuotes] = useState<Record<MarketMode, MarketQuote[]>>({
@@ -57,38 +51,35 @@ export function MarketStrip() {
   }, [fetchQuotes]);
 
   const visibleQuotes = quotes[mode];
+  const columnCount = MARKET_STRIP_COLUMN_COUNTS[mode];
+  const showLoadingSkeletons = loading && visibleQuotes.length === 0;
 
   return (
-    <div className="border-t border-[#27272a] bg-[#111113] px-3 py-2 sm:px-4">
+    <div className="border-t border-[var(--tranche-border-muted)] bg-[#111113] px-3 py-2 sm:px-4">
       <div className="flex min-w-0 items-stretch gap-2">
         <div
-          className="grid min-w-0 flex-1 divide-x divide-[#27272a]"
-          style={{ gridTemplateColumns: `repeat(${mode === "indexes" ? 5 : 8}, minmax(72px, 1fr))` }}
+          className="grid min-w-0 flex-1 divide-x divide-[var(--tranche-border-muted)]"
+          style={{ gridTemplateColumns: `repeat(${columnCount}, minmax(72px, 1fr))` }}
         >
-          {loading && visibleQuotes.length === 0
-            ? Array.from({ length: mode === "indexes" ? 5 : 8 }).map((_, index) => (
+          {showLoadingSkeletons
+            ? Array.from({ length: columnCount }).map((_, index) => (
                 <div key={index} className="space-y-1 px-2 py-0.5">
-                  <Skeleton className="h-3 w-12 bg-[#27272a]" />
-                  <Skeleton className="h-3 w-16 bg-[#27272a]" />
+                  <Skeleton className="h-3 w-12 bg-[var(--tranche-border-muted)]" />
+                  <Skeleton className="h-3 w-16 bg-[var(--tranche-border-muted)]" />
                 </div>
               ))
             : visibleQuotes.map((quote) => {
-                const movementClass =
-                  typeof quote.change === "number"
-                    ? quote.change >= 0
-                      ? "text-[#4ade80]"
-                      : "text-[#f87171]"
-                    : "text-[#71717a]";
+                const movementClass = getMarketMovementClass(quote.change);
                 return (
                   <div key={quote.symbol} className="min-w-0 px-2 py-0.5 text-center">
-                    <p className="truncate text-[10px] font-bold uppercase tracking-[0.08em] text-[#a1a1aa]">
+                    <p className="truncate text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--tranche-muted)]">
                       {quote.label}
                     </p>
                     <p className="mt-0.5 truncate text-xs text-[#f4f4f5] [font-family:var(--font-mono)]">
                       {typeof quote.price === "number" ? priceNumber.format(quote.price) : "--"}
                     </p>
                     <p className={`truncate text-[10px] [font-family:var(--font-mono)] ${movementClass}`}>
-                      {signed(quote.change)} · {signed(quote.changePct, "%")}
+                      {formatSignedNumber(quote.change)} · {formatSignedNumber(quote.changePct, "%")}
                     </p>
                   </div>
                 );
@@ -98,13 +89,13 @@ export function MarketStrip() {
           variant="outline"
           size="sm"
           onClick={() => setMode((current) => (current === "indexes" ? "etfs" : "indexes"))}
-          className="h-auto min-w-[78px] self-stretch border-[#3f3f46] bg-[#18181b] px-2 text-[10px] font-bold uppercase tracking-[0.08em] text-[#e4e4e7] hover:bg-[#27272a]"
+          className="h-auto min-w-[78px] self-stretch border-[var(--tranche-border-strong)] bg-[var(--tranche-panel)] px-2 text-[10px] font-bold uppercase tracking-[0.08em] text-[var(--tranche-text)] hover:bg-[var(--tranche-border-muted)]"
           aria-label={`Show ${mode === "indexes" ? "ETF" : "index"} quotes`}
         >
-          {mode === "indexes" ? "Show ETFs" : "Show Indexes"}
+          Show {mode === "indexes" ? MARKET_STRIP_LABELS.etfs : MARKET_STRIP_LABELS.indexes}
         </Button>
       </div>
-      <p className="mt-1 text-right text-[9px] uppercase tracking-[0.08em] text-[#3f3f46]">
+      <p className="mt-1 text-right text-[9px] uppercase tracking-[0.08em] text-[var(--tranche-border-strong)]">
         Refreshes every 30s · Quotes may be delayed
       </p>
     </div>

--- a/components/tranche/market-strip.tsx
+++ b/components/tranche/market-strip.tsx
@@ -1,0 +1,112 @@
+"use client";
+
+import { useCallback, useEffect, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Skeleton } from "@/components/ui/skeleton";
+
+type MarketMode = "indexes" | "etfs";
+
+interface MarketQuote {
+  symbol: string;
+  label: string;
+  price: number | null;
+  change: number | null;
+  changePct: number | null;
+}
+
+const priceNumber = new Intl.NumberFormat("en-US", {
+  minimumFractionDigits: 2,
+  maximumFractionDigits: 2,
+});
+
+function signed(value: number | null, suffix = "") {
+  if (typeof value !== "number") return "--";
+  return `${value > 0 ? "+" : ""}${value.toFixed(2)}${suffix}`;
+}
+
+export function MarketStrip() {
+  const [mode, setMode] = useState<MarketMode>("indexes");
+  const [quotes, setQuotes] = useState<Record<MarketMode, MarketQuote[]>>({
+    indexes: [],
+    etfs: [],
+  });
+  const [loading, setLoading] = useState(true);
+
+  const fetchQuotes = useCallback(async (signal?: AbortSignal) => {
+    try {
+      const response = await fetch("/api/market-strip", { signal });
+      if (!response.ok) throw new Error("Unable to load market quotes");
+      const data = (await response.json()) as Record<MarketMode, MarketQuote[]>;
+      setQuotes(data);
+    } catch (error) {
+      if (error instanceof DOMException && error.name === "AbortError") return;
+    } finally {
+      if (!signal?.aborted) setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    const controller = new AbortController();
+    void fetchQuotes(controller.signal);
+    const interval = window.setInterval(() => void fetchQuotes(), 30_000);
+    return () => {
+      controller.abort();
+      window.clearInterval(interval);
+    };
+  }, [fetchQuotes]);
+
+  const visibleQuotes = quotes[mode];
+
+  return (
+    <div className="border-t border-[#27272a] bg-[#111113] px-3 py-2 sm:px-4">
+      <div className="flex min-w-0 items-stretch gap-2">
+        <div
+          className="grid min-w-0 flex-1 divide-x divide-[#27272a]"
+          style={{ gridTemplateColumns: `repeat(${mode === "indexes" ? 5 : 8}, minmax(72px, 1fr))` }}
+        >
+          {loading && visibleQuotes.length === 0
+            ? Array.from({ length: mode === "indexes" ? 5 : 8 }).map((_, index) => (
+                <div key={index} className="space-y-1 px-2 py-0.5">
+                  <Skeleton className="h-3 w-12 bg-[#27272a]" />
+                  <Skeleton className="h-3 w-16 bg-[#27272a]" />
+                </div>
+              ))
+            : visibleQuotes.map((quote) => {
+                const movementClass =
+                  typeof quote.change === "number"
+                    ? quote.change >= 0
+                      ? "text-[#4ade80]"
+                      : "text-[#f87171]"
+                    : "text-[#71717a]";
+                return (
+                  <div key={quote.symbol} className="min-w-0 px-2 py-0.5 text-center">
+                    <p className="truncate text-[10px] font-bold uppercase tracking-[0.08em] text-[#a1a1aa]">
+                      {quote.label}
+                    </p>
+                    <p className="mt-0.5 truncate text-xs text-[#f4f4f5] [font-family:var(--font-mono)]">
+                      {typeof quote.price === "number" ? priceNumber.format(quote.price) : "--"}
+                    </p>
+                    <p className={`truncate text-[10px] [font-family:var(--font-mono)] ${movementClass}`}>
+                      {signed(quote.change)} · {signed(quote.changePct, "%")}
+                    </p>
+                  </div>
+                );
+              })}
+        </div>
+        <Button
+          variant="outline"
+          size="sm"
+          onClick={() => setMode((current) => (current === "indexes" ? "etfs" : "indexes"))}
+          className="h-auto min-w-[78px] self-stretch border-[#3f3f46] bg-[#18181b] px-2 text-[10px] font-bold uppercase tracking-[0.08em] text-[#e4e4e7] hover:bg-[#27272a]"
+          aria-label={`Show ${mode === "indexes" ? "ETF" : "index"} quotes`}
+        >
+          {mode === "indexes" ? "Show ETFs" : "Show Indexes"}
+        </Button>
+      </div>
+      <p className="mt-1 text-right text-[9px] uppercase tracking-[0.08em] text-[#3f3f46]">
+        Refreshes every 30s · Quotes may be delayed
+      </p>
+    </div>
+  );
+}

--- a/components/tranche/note-popover.tsx
+++ b/components/tranche/note-popover.tsx
@@ -1,0 +1,65 @@
+"use client";
+
+import { Button } from "@/components/ui/button";
+import { type Position } from "@/lib/store";
+
+interface NotePopoverProps {
+  position: Position;
+  isOpen: boolean;
+  onToggle: () => void;
+  onClose: () => void;
+  onChange: (notes: string) => void;
+}
+
+const NOTE_BUTTON_BASE =
+  "relative h-8 w-8 border hover:bg-[var(--tranche-hover)] hover:text-[var(--tranche-warning)]";
+const NOTE_BUTTON_FILLED =
+  "border-[var(--tranche-warning-border)] bg-[var(--tranche-warning-surface)] text-[var(--tranche-warning)]";
+const NOTE_BUTTON_EMPTY = "border-[var(--tranche-border-muted)] text-[var(--tranche-muted-strong)]";
+
+export function NotePopover({ position, isOpen, onToggle, onClose, onChange }: NotePopoverProps) {
+  const hasNote = position.notes.length > 0;
+
+  return (
+    <div className="relative flex justify-center">
+      <Button
+        variant="ghost"
+        size="icon-sm"
+        onClick={onToggle}
+        className={`${NOTE_BUTTON_BASE} ${hasNote ? NOTE_BUTTON_FILLED : NOTE_BUTTON_EMPTY}`}
+        aria-label={hasNote ? "Open position note" : "Add position note"}
+        aria-expanded={isOpen}
+      >
+        <span aria-hidden="true">✎</span>
+        {hasNote && <span className="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-[var(--tranche-warning)]" />}
+      </Button>
+      {isOpen && (
+        <div className="absolute right-0 top-10 z-30 w-64 rounded-sm border border-[var(--tranche-border-strong)] bg-[var(--tranche-popover)] p-3 shadow-2xl">
+          <div className="mb-2 flex items-center justify-between">
+            <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--tranche-muted)]">
+              {position.ticker || "Position"} note
+            </p>
+            <button
+              type="button"
+              onClick={onClose}
+              className="px-1 text-lg leading-none text-[var(--tranche-muted-strong)] hover:text-[var(--tranche-text)]"
+              aria-label="Close note"
+            >
+              ×
+            </button>
+          </div>
+          <textarea
+            value={position.notes}
+            maxLength={160}
+            placeholder="Add note"
+            disabled={position.locked}
+            autoFocus={!position.locked}
+            onChange={(event) => onChange(event.target.value)}
+            className="h-24 w-full resize-none rounded-sm border border-[var(--tranche-border-muted)] bg-[var(--tranche-page)] px-2 py-2 text-xs leading-4 text-[var(--tranche-text)] outline-none placeholder:text-[var(--tranche-muted-strong)] focus:border-[var(--tranche-warning)] disabled:border-[var(--tranche-success-border)] disabled:text-[var(--tranche-success-soft)]"
+          />
+          <p className="mt-1 text-right text-[10px] text-[var(--tranche-muted-strong)]">{position.notes.length}/160</p>
+        </div>
+      )}
+    </div>
+  );
+}

--- a/components/tranche/share-input.tsx
+++ b/components/tranche/share-input.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { useEffect, useRef, useState } from "react";
+
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+
+interface ShareInputProps {
+  value: number;
+  disabled?: boolean;
+  inputRef?: (node: HTMLInputElement | null) => void;
+  onChange: (value: number) => void;
+}
+
+function formatShareDraft(value: number) {
+  return Number.isFinite(value) ? String(value) : "0";
+}
+
+export function ShareInput({ value, disabled, inputRef, onChange }: ShareInputProps) {
+  const [draft, setDraft] = useState(() => formatShareDraft(value));
+  const focusedRef = useRef(false);
+
+  useEffect(() => {
+    if (!focusedRef.current) {
+      setDraft(formatShareDraft(value));
+    }
+  }, [value]);
+
+  const step = (direction: -1 | 1) => {
+    const next = Math.max(0, value + direction);
+    setDraft(formatShareDraft(next));
+    onChange(next);
+  };
+
+  const commitDraft = () => {
+    const parsed = Number.parseFloat(draft);
+    const next = Number.isFinite(parsed) && parsed >= 0 ? parsed : 0;
+    setDraft(formatShareDraft(next));
+    onChange(next);
+  };
+
+  return (
+    <div className="grid grid-cols-[28px_minmax(60px,1fr)_28px] items-center gap-1">
+      <Button
+        variant="outline"
+        size="icon-sm"
+        disabled={disabled}
+        onClick={() => step(-1)}
+        className="h-8 w-7 border-[#27272a] bg-[#09090b] text-[#e4e4e7] hover:bg-[#202024]"
+        aria-label="Decrease shares by one"
+      >
+        -
+      </Button>
+      <Input
+        ref={inputRef}
+        value={draft}
+        disabled={disabled}
+        inputMode="decimal"
+        aria-label="Shares"
+        onFocus={() => {
+          focusedRef.current = true;
+        }}
+        onChange={(event) => {
+          const nextDraft = event.target.value;
+          if (!/^(?:\d+(?:\.\d*)?|\.\d*)?$/.test(nextDraft)) {
+            return;
+          }
+
+          setDraft(nextDraft);
+          const parsed = Number.parseFloat(nextDraft);
+          if (Number.isFinite(parsed) && parsed >= 0) {
+            onChange(parsed);
+          }
+        }}
+        onBlur={() => {
+          focusedRef.current = false;
+          commitDraft();
+        }}
+        onKeyDown={(event) => {
+          if (event.key === "ArrowUp" || event.key === "ArrowDown") {
+            event.preventDefault();
+            step(event.key === "ArrowUp" ? 1 : -1);
+          }
+          if (event.key === "Enter") {
+            commitDraft();
+            event.currentTarget.select();
+          }
+        }}
+        className="h-8 min-w-0 border-[#27272a] bg-[#09090b] px-1 text-center text-sm [font-family:var(--font-mono)] disabled:border-[#14532d] disabled:text-[#86efac]"
+      />
+      <Button
+        variant="outline"
+        size="icon-sm"
+        disabled={disabled}
+        onClick={() => step(1)}
+        className="h-8 w-7 border-[#27272a] bg-[#09090b] text-[#e4e4e7] hover:bg-[#202024]"
+        aria-label="Increase shares by one"
+      >
+        +
+      </Button>
+    </div>
+  );
+}

--- a/components/tranche/share-input.tsx
+++ b/components/tranche/share-input.tsx
@@ -4,6 +4,7 @@ import { useEffect, useRef, useState } from "react";
 
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
+import { formatShareDraft } from "@/lib/utils/shares";
 
 interface ShareInputProps {
   value: number;
@@ -12,10 +13,7 @@ interface ShareInputProps {
   onChange: (value: number) => void;
 }
 
-function formatShareDraft(value: number) {
-  return Number.isFinite(value) ? String(value) : "0";
-}
-
+// Keeps fractional share drafts editable while syncing valid numbers back to allocation state.
 export function ShareInput({ value, disabled, inputRef, onChange }: ShareInputProps) {
   const [draft, setDraft] = useState(() => formatShareDraft(value));
   const focusedRef = useRef(false);

--- a/docs/plans/2026-06-15-allocation-workspace-enhancements-design.md
+++ b/docs/plans/2026-06-15-allocation-workspace-enhancements-design.md
@@ -1,0 +1,40 @@
+# Allocation Workspace Enhancements
+
+## Goals
+
+- Accept and persist fractional share quantities such as `.250`.
+- Keep the allocation table usable on smaller desktop screens and iPad landscape.
+- Let a focused shares input increment or decrement by one with the arrow keys.
+- Replace the wide notes field with a compact popover.
+- Add a 30-second market strip that toggles between major indexes and selected ETFs.
+- Add reset behavior that respects locked positions.
+
+## Interaction Design
+
+The shares input keeps a local text draft so intermediate decimal values such as `.`, `.2`, and `.250` remain editable. Valid non-negative values update the allocation immediately. Arrow Up and Arrow Down change the stored quantity by one, as do the existing plus and minus buttons.
+
+Notes are represented by a small button in each row. The button indicates whether a note exists and opens an anchored popover containing the editable text area. Locked rows expose their note for reading but do not allow editing.
+
+The header includes a compact market strip with evenly spaced quote cells. Index mode shows S&P 500, Nasdaq, Dow Jones, Russell 2000, and MSCI World. ETF mode shows VOO, QQQ, VTI, VT, VXUS, VONE, IEUR, and EEM. A control at the right switches modes. Quotes refresh every 30 seconds and use green or red daily movement styling. Data may be delayed by the upstream quote provider.
+
+Reset sits beside Save with tighter button spacing:
+
+- When no positions are locked, reset clears all positions and sets the proceeds budget to zero.
+- When locked positions exist, reset opens a modal.
+- Keep Locked preserves the budget and locked rows while removing unlocked rows.
+- Clear All preserves the budget but removes every row, including locked rows.
+
+## Layout
+
+The current dark, dense allocation-workbench aesthetic remains. The notes column contracts to a compact icon column, action buttons form a close group, and the table grid uses smaller minimum widths. At desktop and iPad-landscape widths, the full working row should fit without page-level overflow. At narrower widths, the table retains contained horizontal scrolling rather than compressing controls below usable sizes.
+
+## Data And API
+
+Fractional quantities remain numeric in Zustand persistence and share URLs. A batch market endpoint fetches the configured symbols concurrently through the existing Yahoo chart helper and returns normalized price and daily change data. The client polls that endpoint every 30 seconds and retains the last successful values when a refresh partially fails.
+
+## Validation
+
+- Unit-test share parsing/formatting and reset state transitions where practical.
+- Run TypeScript/build validation.
+- Exercise fractional editing, arrow stepping, notes, reset choices, and quote toggling.
+- Inspect the allocation page at wide desktop, MacBook Air, and iPad-landscape viewport sizes.

--- a/docs/plans/2026-06-15-allocation-workspace-enhancements-design.md
+++ b/docs/plans/2026-06-15-allocation-workspace-enhancements-design.md
@@ -1,40 +1,19 @@
 # Allocation Workspace Enhancements
 
-## Goals
+## Scope
 
-- Accept and persist fractional share quantities such as `.250`.
-- Keep the allocation table usable on smaller desktop screens and iPad landscape.
-- Let a focused shares input increment or decrement by one with the arrow keys.
-- Replace the wide notes field with a compact popover.
-- Add a 30-second market strip that toggles between major indexes and selected ETFs.
-- Add reset behavior that respects locked positions.
+- Fractional share input accepts drafts like `.250`, updates totals live, and steps by one with Arrow Up/Down or +/-.
+- Notes move into a compact per-row popover so the table fits smaller desktop and iPad-landscape widths.
+- The header shows a 30-second quote strip toggling between major indexes and ETFs.
+- Reset clears unlocked allocations directly, but prompts when locked rows exist.
+- History handles paused or unreachable Supabase responses without rendering raw upstream HTML.
 
-## Interaction Design
+## Reset Rules
 
-The shares input keeps a local text draft so intermediate decimal values such as `.`, `.2`, and `.250` remain editable. Valid non-negative values update the allocation immediately. Arrow Up and Arrow Down change the stored quantity by one, as do the existing plus and minus buttons.
-
-Notes are represented by a small button in each row. The button indicates whether a note exists and opens an anchored popover containing the editable text area. Locked rows expose their note for reading but do not allow editing.
-
-The header includes a compact market strip with evenly spaced quote cells. Index mode shows S&P 500, Nasdaq, Dow Jones, Russell 2000, and MSCI World. ETF mode shows VOO, QQQ, VTI, VT, VXUS, VONE, IEUR, and EEM. A control at the right switches modes. Quotes refresh every 30 seconds and use green or red daily movement styling. Data may be delayed by the upstream quote provider.
-
-Reset sits beside Save with tighter button spacing:
-
-- When no positions are locked, reset clears all positions and sets the proceeds budget to zero.
-- When locked positions exist, reset opens a modal.
-- Keep Locked preserves the budget and locked rows while removing unlocked rows.
-- Clear All preserves the budget but removes every row, including locked rows.
-
-## Layout
-
-The current dark, dense allocation-workbench aesthetic remains. The notes column contracts to a compact icon column, action buttons form a close group, and the table grid uses smaller minimum widths. At desktop and iPad-landscape widths, the full working row should fit without page-level overflow. At narrower widths, the table retains contained horizontal scrolling rather than compressing controls below usable sizes.
-
-## Data And API
-
-Fractional quantities remain numeric in Zustand persistence and share URLs. A batch market endpoint fetches the configured symbols concurrently through the existing Yahoo chart helper and returns normalized price and daily change data. The client polls that endpoint every 30 seconds and retains the last successful values when a refresh partially fails.
+- No locked rows: clear positions and set proceeds to zero.
+- Locked rows + Keep locked: preserve budget and locked rows, clear everything else.
+- Locked rows + Clear all: preserve budget, clear all rows.
 
 ## Validation
 
-- Unit-test share parsing/formatting and reset state transitions where practical.
-- Run TypeScript/build validation.
-- Exercise fractional editing, arrow stepping, notes, reset choices, and quote toggling.
-- Inspect the allocation page at wide desktop, MacBook Air, and iPad-landscape viewport sizes.
+Run the production build, check fractional editing and reset choices, verify index/ETF quote toggling, and inspect the allocation/history pages at smaller desktop widths.

--- a/lib/server/allocations.ts
+++ b/lib/server/allocations.ts
@@ -1,4 +1,5 @@
 import { createServerSupabaseClient } from "@/lib/server/supabase";
+import { formatSupabaseError } from "@/lib/server/supabase-errors";
 import { type Position } from "@/lib/store";
 
 export interface AllocationSnapshot {
@@ -38,7 +39,7 @@ export async function saveAllocationSnapshot(input: {
     .single();
 
   if (error) {
-    throw new Error(error.message);
+    throw new Error(formatSupabaseError(error, "Unable to save allocation."));
   }
 
   return data as AllocationSnapshot;
@@ -54,7 +55,7 @@ export async function getAllocationSnapshots() {
     .limit(50);
 
   if (error) {
-    throw new Error(error.message);
+    throw new Error(formatSupabaseError(error, "Unable to load allocation history."));
   }
 
   return (data ?? []) as AllocationSnapshot[];

--- a/lib/server/supabase-errors.ts
+++ b/lib/server/supabase-errors.ts
@@ -8,6 +8,14 @@ const HTML_ERROR_PATTERNS = [
   /gateway timeout/i,
 ];
 
+const CONFIG_ERROR_PATTERNS = [
+  /supabase is not configured/i,
+  /allocation_snapshots/i,
+  /relation .* does not exist/i,
+  /schema cache/i,
+  /could not find the table/i,
+];
+
 const MAX_ERROR_LENGTH = 220;
 
 export const SUPABASE_UNAVAILABLE_MESSAGE =
@@ -36,6 +44,10 @@ export function getErrorMessage(error: unknown): string {
 
 export function isSupabaseUnavailableError(message: string) {
   return HTML_ERROR_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+export function isSupabaseConfigError(message: string) {
+  return CONFIG_ERROR_PATTERNS.some((pattern) => pattern.test(message));
 }
 
 export function formatSupabaseError(error: unknown, fallback: string) {

--- a/lib/server/supabase-errors.ts
+++ b/lib/server/supabase-errors.ts
@@ -1,0 +1,57 @@
+const HTML_ERROR_PATTERNS = [
+  /<!doctype html/i,
+  /<html[\s>]/i,
+  /cloudflare/i,
+  /error code 52[0-9]/i,
+  /web server is down/i,
+  /bad gateway/i,
+  /gateway timeout/i,
+];
+
+const MAX_ERROR_LENGTH = 220;
+
+export const SUPABASE_UNAVAILABLE_MESSAGE =
+  "Allocation history is temporarily unavailable because Supabase is not reachable. If the project was paused for inactivity, resume it in Supabase, wait a minute, then refresh this page.";
+
+export function getErrorMessage(error: unknown): string {
+  if (error instanceof Error) {
+    return error.message;
+  }
+
+  if (
+    typeof error === "object" &&
+    error !== null &&
+    "message" in error &&
+    typeof error.message === "string"
+  ) {
+    return error.message;
+  }
+
+  if (typeof error === "string") {
+    return error;
+  }
+
+  return "Unexpected server error.";
+}
+
+export function isSupabaseUnavailableError(message: string) {
+  return HTML_ERROR_PATTERNS.some((pattern) => pattern.test(message));
+}
+
+export function formatSupabaseError(error: unknown, fallback: string) {
+  const message = getErrorMessage(error).trim();
+
+  if (!message) {
+    return fallback;
+  }
+
+  if (isSupabaseUnavailableError(message)) {
+    return SUPABASE_UNAVAILABLE_MESSAGE;
+  }
+
+  if (message.length > MAX_ERROR_LENGTH) {
+    return `${fallback} ${message.slice(0, MAX_ERROR_LENGTH).trim()}...`;
+  }
+
+  return message;
+}

--- a/lib/store.ts
+++ b/lib/store.ts
@@ -51,6 +51,7 @@ interface Store {
   setPerf: (id: string, perf: PositionPerf) => void;
   resetMarketData: () => void;
   clearAllocations: () => void;
+  clearUnlockedAllocations: () => void;
   clearEverything: () => void;
   replaceFromShareState: (budget: number | null, positions: ReplacePositionInput[]) => void;
 }
@@ -251,6 +252,13 @@ export const useTrancheStore = create<Store>()(
         set(() => ({
           positions: [createEmptyPosition()],
         })),
+      clearUnlockedAllocations: () =>
+        set((state) => {
+          const lockedPositions = state.positions.filter((position) => position.locked);
+          return {
+            positions: lockedPositions.length > 0 ? lockedPositions : [createEmptyPosition()],
+          };
+        }),
       clearEverything: () =>
         set(() => ({
           budget: 0,

--- a/lib/utils/market-strip.ts
+++ b/lib/utils/market-strip.ts
@@ -1,0 +1,34 @@
+export type MarketMode = "indexes" | "etfs";
+
+export interface MarketQuote {
+  symbol: string;
+  label: string;
+  price: number | null;
+  change: number | null;
+  changePct: number | null;
+}
+
+export interface MarketDefinition {
+  symbol: string;
+  label: string;
+}
+
+export const MARKET_STRIP_LABELS: Record<MarketMode, string> = {
+  indexes: "Indexes",
+  etfs: "ETFs",
+};
+
+export const MARKET_STRIP_COLUMN_COUNTS: Record<MarketMode, number> = {
+  indexes: 5,
+  etfs: 8,
+};
+
+export function formatSignedNumber(value: number | null, suffix = "") {
+  if (typeof value !== "number") return "--";
+  return `${value > 0 ? "+" : ""}${value.toFixed(2)}${suffix}`;
+}
+
+export function getMarketMovementClass(change: number | null) {
+  if (typeof change !== "number") return "text-[var(--tranche-muted-strong)]";
+  return change >= 0 ? "text-[var(--tranche-success)]" : "text-[var(--tranche-danger)]";
+}

--- a/lib/utils/shares.ts
+++ b/lib/utils/shares.ts
@@ -1,0 +1,3 @@
+export function formatShareDraft(value: number) {
+  return Number.isFinite(value) ? String(value) : "0";
+}


### PR DESCRIPTION
## Summary
- Add a live market strip with index/ETF toggling and periodic refreshes.
- Support fractional share entry with keyboard step controls via a dedicated share input.
- Replace the inline notes field with a compact note popover and tighten the allocation table layout.
- Improve reset behavior so locked positions are handled explicitly.
- Make Supabase history errors clearer when the issue is configuration versus a temporary outage.

## Testing
- Not run (not requested).
- Validated the new interaction paths by reasoning through the updated share input, note popover, reset flow, and history error states.