### PR TITLE
Polish allocation popovers and market strip

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -56,3 +56,15 @@
     font-family: var(--font-ui), sans-serif;
   }
 }
+
+.market-movement-up {
+  color: var(--tranche-success);
+}
+
+.market-movement-down {
+  color: var(--tranche-danger);
+}
+
+.market-movement-flat {
+  color: var(--tranche-muted-strong);
+}

--- a/components/tranche/allocation-page.tsx
+++ b/components/tranche/allocation-page.tsx
@@ -141,6 +141,7 @@ export default function Home() {
   const [saving, setSaving] = useState(false);
   const [activeNoteId, setActiveNoteId] = useState<string | null>(null);
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
+  const [pricePopoverPosition, setPricePopoverPosition] = useState({ top: 0, left: 0 });
 
   const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -385,9 +386,15 @@ export default function Home() {
   );
 
   const handlePositionMouseEnter = useCallback(
-    (position: Position) => {
+    (position: Position, anchor: HTMLElement) => {
       if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
       if (openTimerRef.current) clearTimeout(openTimerRef.current);
+      const rect = anchor.getBoundingClientRect();
+      const viewportPadding = 12;
+      setPricePopoverPosition({
+        top: Math.min(rect.bottom + 8, window.innerHeight - 270),
+        left: Math.min(Math.max(rect.left, viewportPadding), window.innerWidth - 268),
+      });
       openTimerRef.current = setTimeout(() => {
         setActivePopoverId(position.id);
         void fetchPerf(position);
@@ -604,8 +611,8 @@ export default function Home() {
           />
         </header>
 
-        <section className="overflow-x-auto rounded-sm border border-[#1a1a1e] bg-[#18181b]">
-          <div className="grid min-w-[860px] grid-cols-[22px_26px_82px_minmax(190px,1fr)_130px_102px_78px_44px_44px] items-center gap-2 border-b border-[#27272a] bg-[#111113] px-2 py-3 text-[11px] font-bold uppercase tracking-[0.1em] text-[#7d8592] sm:px-3">
+        <section className="overflow-x-auto overflow-y-hidden rounded-sm border border-[#1a1a1e] bg-[#18181b]">
+          <div className="grid min-w-[872px] grid-cols-[22px_26px_82px_minmax(190px,1fr)_130px_102px_78px_44px_56px] items-center gap-2 border-b border-[#27272a] bg-[#111113] px-2 py-3 text-[11px] font-bold uppercase tracking-[0.1em] text-[#d4d4d8] sm:px-3">
             <span className="text-center">#</span>
             <span className="text-center text-sm tracking-normal">✓</span>
             <span>Ticker</span>
@@ -663,7 +670,7 @@ export default function Home() {
                   onDragLeave={() => setDragOverId(null)}
                   onDrop={(event) => handleDrop(event, position.id)}
                   onDragEnd={() => setDragOverId(null)}
-                  className={`grid min-w-[860px] cursor-grab grid-cols-[22px_26px_82px_minmax(190px,1fr)_130px_102px_78px_44px_44px] items-center gap-2 px-2 py-3 active:cursor-grabbing sm:px-3 ${
+                  className={`grid min-w-[872px] cursor-grab grid-cols-[22px_26px_82px_minmax(190px,1fr)_130px_102px_78px_44px_56px] items-center gap-2 px-2 py-3 active:cursor-grabbing sm:px-3 ${
                     dragOverId === position.id ? "bg-[#202024]" : position.locked ? "bg-[#111816]" : ""
                   }`}
                 >
@@ -694,7 +701,7 @@ export default function Home() {
 
                   <div
                     className="relative"
-                    onMouseEnter={() => handlePositionMouseEnter(position)}
+                    onMouseEnter={(event) => handlePositionMouseEnter(position, event.currentTarget)}
                     onMouseLeave={handlePositionMouseLeave}
                   >
                     {position.loading ? (
@@ -732,7 +739,8 @@ export default function Home() {
 
                     {showPopover && (
                       <div
-                        className="absolute left-0 top-[calc(100%+8px)] z-20 w-64 rounded-sm border border-[#27272a] bg-[#121214] p-3 shadow-xl"
+                        className="fixed z-50 w-64 rounded-sm border border-[#27272a] bg-[#121214] p-3 shadow-xl"
+                        style={{ top: pricePopoverPosition.top, left: pricePopoverPosition.left }}
                         onMouseEnter={handlePopoverMouseEnter}
                         onMouseLeave={handlePopoverMouseLeave}
                       >
@@ -787,7 +795,7 @@ export default function Home() {
                     size="icon-sm"
                     disabled={position.locked}
                     onClick={() => removePosition(position.id)}
-                    className="h-8 w-8 text-2xl leading-none text-[#a1a1aa] hover:bg-[#202024] hover:text-[#f87171]"
+                    className="h-10 w-10 justify-self-center text-3xl leading-none text-[#c4c4cc] hover:bg-[#202024] hover:text-[#f87171]"
                     aria-label="Remove position"
                   >
                     ×

--- a/components/tranche/allocation-page.tsx
+++ b/components/tranche/allocation-page.tsx
@@ -2,6 +2,7 @@
 
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 import Link from "next/link";
+import { PreviewCard } from "@base-ui/react/preview-card";
 import { toast } from "sonner";
 
 import { MarketStrip } from "@/components/tranche/market-strip";
@@ -142,8 +143,6 @@ export default function Home() {
   const [activeNoteId, setActiveNoteId] = useState<string | null>(null);
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
 
-  const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-  const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const tickerInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
   const shareInputRefs = useRef<Record<string, HTMLInputElement | null>>({});
   const priceRequestSeqRef = useRef<Record<string, number>>({});
@@ -167,17 +166,6 @@ export default function Home() {
   const progressRatio = budget > 0 ? allocated / budget : 0;
   const progressValue = Math.max(0, Math.min(progressRatio * 100, 100));
   const progressColorClass = getProgressColor(progressRatio);
-
-  const clearTimers = useCallback(() => {
-    if (openTimerRef.current) {
-      clearTimeout(openTimerRef.current);
-      openTimerRef.current = null;
-    }
-    if (closeTimerRef.current) {
-      clearTimeout(closeTimerRef.current);
-      closeTimerRef.current = null;
-    }
-  }, []);
 
   const fetchPrice = useCallback(
     async (positionId: string, ticker: string) => {
@@ -333,12 +321,6 @@ export default function Home() {
     });
   }, [fetchPrice, hasHydrated, replaceFromShareState, resetMarketData]);
 
-  useEffect(() => {
-    return () => {
-      clearTimers();
-    };
-  }, [clearTimers]);
-
   const commitBudgetEdit = useCallback(() => {
     const parsed = Number.parseFloat(budgetDraft.replace(/[$, ]/g, ""));
     if (Number.isFinite(parsed)) {
@@ -383,35 +365,6 @@ export default function Home() {
     },
     [fetchPrice],
   );
-
-  const handlePositionMouseEnter = useCallback(
-    (position: Position) => {
-      if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
-      if (openTimerRef.current) clearTimeout(openTimerRef.current);
-      openTimerRef.current = setTimeout(() => {
-        setActivePopoverId(position.id);
-        void fetchPerf(position);
-      }, 180);
-    },
-    [fetchPerf],
-  );
-
-  const handlePositionMouseLeave = useCallback(() => {
-    if (openTimerRef.current) clearTimeout(openTimerRef.current);
-    closeTimerRef.current = setTimeout(() => {
-      setActivePopoverId(null);
-    }, 130);
-  }, []);
-
-  const handlePopoverMouseEnter = useCallback(() => {
-    if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
-  }, []);
-
-  const handlePopoverMouseLeave = useCallback(() => {
-    closeTimerRef.current = setTimeout(() => {
-      setActivePopoverId(null);
-    }, 130);
-  }, []);
 
   const requestReset = useCallback(() => {
     const hasLockedPositions = useTrancheStore.getState().positions.some((position) => position.locked);
@@ -693,73 +646,92 @@ export default function Home() {
                     className="h-9 border-[#27272a] bg-[#09090b] px-2 text-center text-base font-semibold uppercase text-[#f59e0b] [font-family:var(--font-mono)] placeholder:text-[#3f3f46] disabled:border-[#14532d] disabled:text-[#86efac]"
                   />
 
-                  <div
-                    className="relative"
-                    onMouseEnter={() => handlePositionMouseEnter(position)}
-                    onMouseLeave={handlePositionMouseLeave}
+                  <PreviewCard.Root
+                    open={showPopover}
+                    onOpenChange={(open) => {
+                      if (open) {
+                        if (typeof displayPrice === "number" && !position.error) {
+                          setActivePopoverId(position.id);
+                          void fetchPerf(position);
+                        }
+                        return;
+                      }
+                      setActivePopoverId((current) => (current === position.id ? null : current));
+                    }}
                   >
-                    {position.loading ? (
-                      <div className="space-y-2 py-0.5">
-                        <Skeleton className="h-3 w-44 bg-[#27272a]" />
-                        <Skeleton className="h-3 w-28 bg-[#27272a]" />
-                      </div>
-                    ) : position.error ? (
-                      <p className="text-sm text-[#f87171]">{position.error}</p>
-                    ) : (
-                      <div className="flex items-center gap-2">
-                        <div className="min-w-0">
-                          <p className="truncate text-xs font-medium text-[#ffffff]">
-                            {position.name || (position.ticker ? "Waiting for quote" : "Enter ticker")}
-                          </p>
-                          {typeof displayPrice === "number" ? (
-                            <p className="mt-0.5 flex items-center gap-2 text-sm [font-family:var(--font-mono)]">
-                              <span className={position.locked ? "text-[#86efac]" : "text-[#4ade80]"}>
-                                {currency.format(displayPrice)}
-                              </span>
-                              <span className={perfColor(position.changePct1D)}>{formatSignedPct(position.changePct1D)}</span>
-                              <span className="text-[#52525b]">...</span>
-                              {position.locked && (
-                                <span className="rounded-sm border border-[#14532d] px-1.5 py-0.5 text-[10px] uppercase tracking-[0.1em] text-[#86efac]">
-                                  Locked
-                                </span>
-                              )}
-                            </p>
+                    <PreviewCard.Trigger
+                      delay={180}
+                      closeDelay={130}
+                      render={
+                        <div>
+                          {position.loading ? (
+                            <div className="space-y-2 py-0.5">
+                              <Skeleton className="h-3 w-44 bg-[#27272a]" />
+                              <Skeleton className="h-3 w-28 bg-[#27272a]" />
+                            </div>
+                          ) : position.error ? (
+                            <p className="text-sm text-[#f87171]">{position.error}</p>
                           ) : (
-                            <p className="mt-0.5 text-sm text-[#52525b] [font-family:var(--font-mono)]">--</p>
+                            <div className="flex items-center gap-2">
+                              <div className="min-w-0">
+                                <p className="truncate text-xs font-medium text-[#ffffff]">
+                                  {position.name || (position.ticker ? "Waiting for quote" : "Enter ticker")}
+                                </p>
+                                {typeof displayPrice === "number" ? (
+                                  <p className="mt-0.5 flex items-center gap-2 text-sm [font-family:var(--font-mono)]">
+                                    <span className={position.locked ? "text-[#86efac]" : "text-[#4ade80]"}>
+                                      {currency.format(displayPrice)}
+                                    </span>
+                                    <span className={perfColor(position.changePct1D)}>
+                                      {formatSignedPct(position.changePct1D)}
+                                    </span>
+                                    <span className="text-[#52525b]">...</span>
+                                    {position.locked && (
+                                      <span className="rounded-sm border border-[#14532d] px-1.5 py-0.5 text-[10px] uppercase tracking-[0.1em] text-[#86efac]">
+                                        Locked
+                                      </span>
+                                    )}
+                                  </p>
+                                ) : (
+                                  <p className="mt-0.5 text-sm text-[#52525b] [font-family:var(--font-mono)]">--</p>
+                                )}
+                              </div>
+                            </div>
                           )}
                         </div>
-                      </div>
-                    )}
-
-                    {showPopover && (
-                      <div
-                        className="absolute left-0 top-[calc(100%+8px)] z-50 w-64 rounded-sm border border-[#27272a] bg-[#121214] p-3 shadow-xl"
-                        onMouseEnter={handlePopoverMouseEnter}
-                        onMouseLeave={handlePopoverMouseLeave}
-                      >
-                        <p className="text-lg text-[#e4e4e7] [font-family:var(--font-mono)]">
-                          {currency.format(displayPrice ?? 0)}
-                        </p>
-                        <p className={`mt-1 text-sm ${perfColor(position.changePct1D)}`}>
-                          {typeof position.changePct1D === "number"
-                            ? `${position.changePct1D >= 0 ? "▲" : "▼"} ${formatSignedPct(position.changePct1D)} today`
-                            : "-- today"}
-                        </p>
-                        <div className="mt-3 space-y-2">
-                          {perfRows.map((row) => (
-                            <div key={row.label} className="grid grid-cols-[24px_44px_1fr] items-center gap-2 text-xs">
-                              <span className="text-[#a1a1aa]">{row.label}</span>
-                              {row.loading ? <Skeleton className="h-1.5 w-11 bg-[#27272a]" /> : <PerfBar value={row.value} />}
-                              <span className={`text-right [font-family:var(--font-mono)] ${perfColor(row.value)}`}>
-                                {row.loading ? <Skeleton className="ml-auto h-3 w-12 bg-[#27272a]" /> : formatSignedPct(row.value)}
-                              </span>
-                            </div>
-                          ))}
-                        </div>
-                        <p className="mt-3 text-[11px] text-[#52525b]">Prices may be delayed</p>
-                      </div>
-                    )}
-                  </div>
+                      }
+                    />
+                    <PreviewCard.Portal>
+                      <PreviewCard.Positioner side="bottom" align="start" sideOffset={8} collisionPadding={12}>
+                        <PreviewCard.Popup className="z-50 w-64 rounded-sm border border-[#27272a] bg-[#121214] p-3 shadow-xl">
+                          <p className="text-lg text-[#e4e4e7] [font-family:var(--font-mono)]">
+                            {currency.format(displayPrice ?? 0)}
+                          </p>
+                          <p className={`mt-1 text-sm ${perfColor(position.changePct1D)}`}>
+                            {typeof position.changePct1D === "number"
+                              ? `${position.changePct1D >= 0 ? "▲" : "▼"} ${formatSignedPct(position.changePct1D)} today`
+                              : "-- today"}
+                          </p>
+                          <div className="mt-3 space-y-2">
+                            {perfRows.map((row) => (
+                              <div key={row.label} className="grid grid-cols-[24px_44px_1fr] items-center gap-2 text-xs">
+                                <span className="text-[#a1a1aa]">{row.label}</span>
+                                {row.loading ? <Skeleton className="h-1.5 w-11 bg-[#27272a]" /> : <PerfBar value={row.value} />}
+                                <span className={`text-right [font-family:var(--font-mono)] ${perfColor(row.value)}`}>
+                                  {row.loading ? (
+                                    <Skeleton className="ml-auto h-3 w-12 bg-[#27272a]" />
+                                  ) : (
+                                    formatSignedPct(row.value)
+                                  )}
+                                </span>
+                              </div>
+                            ))}
+                          </div>
+                          <p className="mt-3 text-[11px] text-[#52525b]">Prices may be delayed</p>
+                        </PreviewCard.Popup>
+                      </PreviewCard.Positioner>
+                    </PreviewCard.Portal>
+                  </PreviewCard.Root>
 
                   <ShareInput
                     value={position.shares}

--- a/components/tranche/allocation-page.tsx
+++ b/components/tranche/allocation-page.tsx
@@ -141,7 +141,6 @@ export default function Home() {
   const [saving, setSaving] = useState(false);
   const [activeNoteId, setActiveNoteId] = useState<string | null>(null);
   const [resetDialogOpen, setResetDialogOpen] = useState(false);
-  const [pricePopoverPosition, setPricePopoverPosition] = useState({ top: 0, left: 0 });
 
   const openTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
   const closeTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null);
@@ -386,15 +385,9 @@ export default function Home() {
   );
 
   const handlePositionMouseEnter = useCallback(
-    (position: Position, anchor: HTMLElement) => {
+    (position: Position) => {
       if (closeTimerRef.current) clearTimeout(closeTimerRef.current);
       if (openTimerRef.current) clearTimeout(openTimerRef.current);
-      const rect = anchor.getBoundingClientRect();
-      const viewportPadding = 12;
-      setPricePopoverPosition({
-        top: Math.min(rect.bottom + 8, window.innerHeight - 270),
-        left: Math.min(Math.max(rect.left, viewportPadding), window.innerWidth - 268),
-      });
       openTimerRef.current = setTimeout(() => {
         setActivePopoverId(position.id);
         void fetchPerf(position);
@@ -611,20 +604,21 @@ export default function Home() {
           />
         </header>
 
-        <section className="overflow-x-auto overflow-y-hidden rounded-sm border border-[#1a1a1e] bg-[#18181b]">
-          <div className="grid min-w-[872px] grid-cols-[22px_26px_82px_minmax(190px,1fr)_130px_102px_78px_44px_56px] items-center gap-2 border-b border-[#27272a] bg-[#111113] px-2 py-3 text-[11px] font-bold uppercase tracking-[0.1em] text-[#d4d4d8] sm:px-3">
-            <span className="text-center">#</span>
-            <span className="text-center text-sm tracking-normal">✓</span>
-            <span>Ticker</span>
-            <span>Name / Price</span>
-            <span className="text-center">Shares</span>
-            <span className="text-right">Total</span>
-            <span className="text-center">% Budget</span>
-            <span className="text-center">Note</span>
-            <span className="text-center">Del</span>
-          </div>
+        <section className="relative rounded-sm border border-[#1a1a1e] bg-[#18181b]">
+          <div className="overflow-x-auto overflow-y-hidden">
+            <div className="grid min-w-[872px] grid-cols-[22px_26px_82px_minmax(190px,1fr)_130px_102px_78px_44px_56px] items-center gap-2 border-b border-[#27272a] bg-[#111113] px-2 py-3 text-[11px] font-bold uppercase tracking-[0.1em] text-[#d4d4d8] sm:px-3">
+              <span className="text-center">#</span>
+              <span className="text-center text-sm tracking-normal">✓</span>
+              <span>Ticker</span>
+              <span>Name / Price</span>
+              <span className="text-center">Shares</span>
+              <span className="text-right">Total</span>
+              <span className="text-center">% Budget</span>
+              <span className="text-center">Note</span>
+              <span className="text-center">Del</span>
+            </div>
 
-          <div className="divide-y divide-[#1a1a1e]">
+            <div className="divide-y divide-[#1a1a1e]">
             {positions.map((position, index) => {
               const displayPrice = position.locked ? position.lockedPrice : position.price;
               const total = typeof displayPrice === "number" ? displayPrice * position.shares : 0;
@@ -701,7 +695,7 @@ export default function Home() {
 
                   <div
                     className="relative"
-                    onMouseEnter={(event) => handlePositionMouseEnter(position, event.currentTarget)}
+                    onMouseEnter={() => handlePositionMouseEnter(position)}
                     onMouseLeave={handlePositionMouseLeave}
                   >
                     {position.loading ? (
@@ -739,8 +733,7 @@ export default function Home() {
 
                     {showPopover && (
                       <div
-                        className="fixed z-50 w-64 rounded-sm border border-[#27272a] bg-[#121214] p-3 shadow-xl"
-                        style={{ top: pricePopoverPosition.top, left: pricePopoverPosition.left }}
+                        className="absolute left-0 top-[calc(100%+8px)] z-50 w-64 rounded-sm border border-[#27272a] bg-[#121214] p-3 shadow-xl"
                         onMouseEnter={handlePopoverMouseEnter}
                         onMouseLeave={handlePopoverMouseLeave}
                       >
@@ -803,19 +796,20 @@ export default function Home() {
                 </div>
               );
             })}
-          </div>
+            </div>
 
-          <div className="p-4">
-            <Button
-              variant="outline"
-              onClick={() => {
-                const newId = addPosition();
-                requestAnimationFrame(() => tickerInputRefs.current[newId]?.focus());
-              }}
-              className="h-10 w-full border border-dashed border-[#3f3f46] bg-transparent text-sm tracking-[0.14em] text-[#a1a1aa] hover:bg-[#202024] hover:text-[#e4e4e7]"
-            >
-              + ADD POSITION
-            </Button>
+            <div className="p-4">
+              <Button
+                variant="outline"
+                onClick={() => {
+                  const newId = addPosition();
+                  requestAnimationFrame(() => tickerInputRefs.current[newId]?.focus());
+                }}
+                className="h-10 w-full border border-dashed border-[#3f3f46] bg-transparent text-sm tracking-[0.14em] text-[#a1a1aa] hover:bg-[#202024] hover:text-[#e4e4e7]"
+              >
+                + ADD POSITION
+              </Button>
+            </div>
           </div>
         </section>
       </div>

--- a/components/tranche/market-strip.tsx
+++ b/components/tranche/market-strip.tsx
@@ -55,7 +55,10 @@ export function MarketStrip() {
   const showLoadingSkeletons = loading && visibleQuotes.length === 0;
 
   return (
-    <div className="border-t border-[var(--tranche-border-muted)] bg-[#111113] px-3 py-2 sm:px-4">
+    <div className="relative border-t border-[var(--tranche-border-muted)] bg-[#111113] px-3 py-2 sm:px-4">
+      <p className="absolute right-3 top-0 -translate-y-1/2 bg-[var(--tranche-panel)] px-2 text-[9px] uppercase tracking-[0.08em] text-[var(--tranche-border-strong)] sm:right-4">
+        Refreshes every 30s · Quotes may be delayed
+      </p>
       <div className="flex min-w-0 items-stretch gap-2">
         <div
           className="grid min-w-0 flex-1 divide-x divide-[var(--tranche-border-muted)]"
@@ -78,7 +81,7 @@ export function MarketStrip() {
                     <p className="mt-0.5 truncate text-xs text-[#f4f4f5] [font-family:var(--font-mono)]">
                       {typeof quote.price === "number" ? priceNumber.format(quote.price) : "--"}
                     </p>
-                    <p className={`truncate text-[10px] [font-family:var(--font-mono)] ${movementClass}`}>
+                    <p className={`truncate text-[10px] font-semibold [font-family:var(--font-mono)] ${movementClass}`}>
                       {formatSignedNumber(quote.change)} · {formatSignedNumber(quote.changePct, "%")}
                     </p>
                   </div>
@@ -95,9 +98,6 @@ export function MarketStrip() {
           Show {mode === "indexes" ? MARKET_STRIP_LABELS.etfs : MARKET_STRIP_LABELS.indexes}
         </Button>
       </div>
-      <p className="mt-1 text-right text-[9px] uppercase tracking-[0.08em] text-[var(--tranche-border-strong)]">
-        Refreshes every 30s · Quotes may be delayed
-      </p>
     </div>
   );
 }

--- a/components/tranche/note-popover.tsx
+++ b/components/tranche/note-popover.tsx
@@ -1,7 +1,5 @@
 "use client";
 
-import { useEffect, useRef, useState } from "react";
-
 import { Button } from "@/components/ui/button";
 import { type Position } from "@/lib/store";
 
@@ -18,42 +16,13 @@ const NOTE_BUTTON_BASE =
 const NOTE_BUTTON_FILLED =
   "border-[var(--tranche-warning-border)] bg-[var(--tranche-warning-surface)] text-[var(--tranche-warning)]";
 const NOTE_BUTTON_EMPTY = "border-[var(--tranche-border-muted)] text-[var(--tranche-muted-strong)]";
-const POPOVER_WIDTH = 320;
 
 export function NotePopover({ position, isOpen, onToggle, onClose, onChange }: NotePopoverProps) {
   const hasNote = position.notes.length > 0;
-  const buttonRef = useRef<HTMLButtonElement | null>(null);
-  const [popoverPosition, setPopoverPosition] = useState({ top: 0, left: 0 });
-
-  useEffect(() => {
-    if (!isOpen) return;
-
-    const updatePosition = () => {
-      const rect = buttonRef.current?.getBoundingClientRect();
-      if (!rect) return;
-
-      const viewportPadding = 12;
-      const left = Math.min(
-        Math.max(rect.right - POPOVER_WIDTH, viewportPadding),
-        window.innerWidth - POPOVER_WIDTH - viewportPadding,
-      );
-      const top = Math.min(rect.bottom + 10, window.innerHeight - 190);
-      setPopoverPosition({ top: Math.max(top, viewportPadding), left });
-    };
-
-    updatePosition();
-    window.addEventListener("resize", updatePosition);
-    window.addEventListener("scroll", updatePosition, true);
-    return () => {
-      window.removeEventListener("resize", updatePosition);
-      window.removeEventListener("scroll", updatePosition, true);
-    };
-  }, [isOpen]);
 
   return (
     <div className="relative flex justify-center">
       <Button
-        ref={buttonRef}
         variant="ghost"
         size="icon-sm"
         onClick={onToggle}
@@ -65,10 +34,7 @@ export function NotePopover({ position, isOpen, onToggle, onClose, onChange }: N
         {hasNote && <span className="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-[var(--tranche-warning)]" />}
       </Button>
       {isOpen && (
-        <div
-          className="fixed z-50 w-80 rounded-sm border border-[var(--tranche-border-strong)] bg-[var(--tranche-popover)] p-3 shadow-2xl"
-          style={{ top: popoverPosition.top, left: popoverPosition.left }}
-        >
+        <div className="absolute right-0 top-10 z-50 w-80 rounded-sm border border-[var(--tranche-border-strong)] bg-[var(--tranche-popover)] p-3 shadow-2xl">
           <div className="mb-2 flex items-center justify-between">
             <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--tranche-muted)]">
               {position.ticker || "Position"} note

--- a/components/tranche/note-popover.tsx
+++ b/components/tranche/note-popover.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { Popover } from "@base-ui/react/popover";
+
 import { Button } from "@/components/ui/button";
 import { type Position } from "@/lib/store";
 
@@ -21,32 +23,38 @@ export function NotePopover({ position, isOpen, onToggle, onClose, onChange }: N
   const hasNote = position.notes.length > 0;
 
   return (
-    <div className="relative flex justify-center">
-      <Button
-        variant="ghost"
-        size="icon-sm"
-        onClick={onToggle}
-        className={`${NOTE_BUTTON_BASE} ${hasNote ? NOTE_BUTTON_FILLED : NOTE_BUTTON_EMPTY}`}
-        aria-label={hasNote ? "Open position note" : "Add position note"}
-        aria-expanded={isOpen}
-      >
-        <span aria-hidden="true">✎</span>
-        {hasNote && <span className="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-[var(--tranche-warning)]" />}
-      </Button>
-      {isOpen && (
-        <div className="absolute right-0 top-10 z-50 w-80 rounded-sm border border-[var(--tranche-border-strong)] bg-[var(--tranche-popover)] p-3 shadow-2xl">
+    <Popover.Root open={isOpen} onOpenChange={(open) => (open ? onToggle() : onClose())}>
+      <div className="flex justify-center">
+        <Popover.Trigger
+          render={
+            <Button
+              variant="ghost"
+              size="icon-sm"
+              className={`${NOTE_BUTTON_BASE} ${hasNote ? NOTE_BUTTON_FILLED : NOTE_BUTTON_EMPTY}`}
+              aria-label={hasNote ? "Open position note" : "Add position note"}
+            >
+              <span aria-hidden="true">✎</span>
+              {hasNote && (
+                <span className="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-[var(--tranche-warning)]" />
+              )}
+            </Button>
+          }
+        />
+      </div>
+      <Popover.Portal>
+        <Popover.Positioner side="bottom" align="end" sideOffset={8} collisionPadding={12}>
+          <Popover.Popup className="z-50 w-80 rounded-sm border border-[var(--tranche-border-strong)] bg-[var(--tranche-popover)] p-3 shadow-2xl">
           <div className="mb-2 flex items-center justify-between">
             <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--tranche-muted)]">
               {position.ticker || "Position"} note
             </p>
-            <button
-              type="button"
+            <Popover.Close
               onClick={onClose}
               className="px-1 text-lg leading-none text-[var(--tranche-muted-strong)] hover:text-[var(--tranche-text)]"
               aria-label="Close note"
             >
               ×
-            </button>
+            </Popover.Close>
           </div>
           <textarea
             value={position.notes}
@@ -58,8 +66,9 @@ export function NotePopover({ position, isOpen, onToggle, onClose, onChange }: N
             className="h-24 w-full resize-none rounded-sm border border-[var(--tranche-border-muted)] bg-[var(--tranche-page)] px-2 py-2 text-xs leading-4 text-[var(--tranche-text)] outline-none placeholder:text-[var(--tranche-muted-strong)] focus:border-[var(--tranche-warning)] disabled:border-[var(--tranche-success-border)] disabled:text-[var(--tranche-success-soft)]"
           />
           <p className="mt-1 text-right text-[10px] text-[var(--tranche-muted-strong)]">{position.notes.length}/160</p>
-        </div>
-      )}
-    </div>
+          </Popover.Popup>
+        </Popover.Positioner>
+      </Popover.Portal>
+    </Popover.Root>
   );
 }

--- a/components/tranche/note-popover.tsx
+++ b/components/tranche/note-popover.tsx
@@ -1,5 +1,7 @@
 "use client";
 
+import { useEffect, useRef, useState } from "react";
+
 import { Button } from "@/components/ui/button";
 import { type Position } from "@/lib/store";
 
@@ -16,13 +18,42 @@ const NOTE_BUTTON_BASE =
 const NOTE_BUTTON_FILLED =
   "border-[var(--tranche-warning-border)] bg-[var(--tranche-warning-surface)] text-[var(--tranche-warning)]";
 const NOTE_BUTTON_EMPTY = "border-[var(--tranche-border-muted)] text-[var(--tranche-muted-strong)]";
+const POPOVER_WIDTH = 320;
 
 export function NotePopover({ position, isOpen, onToggle, onClose, onChange }: NotePopoverProps) {
   const hasNote = position.notes.length > 0;
+  const buttonRef = useRef<HTMLButtonElement | null>(null);
+  const [popoverPosition, setPopoverPosition] = useState({ top: 0, left: 0 });
+
+  useEffect(() => {
+    if (!isOpen) return;
+
+    const updatePosition = () => {
+      const rect = buttonRef.current?.getBoundingClientRect();
+      if (!rect) return;
+
+      const viewportPadding = 12;
+      const left = Math.min(
+        Math.max(rect.right - POPOVER_WIDTH, viewportPadding),
+        window.innerWidth - POPOVER_WIDTH - viewportPadding,
+      );
+      const top = Math.min(rect.bottom + 10, window.innerHeight - 190);
+      setPopoverPosition({ top: Math.max(top, viewportPadding), left });
+    };
+
+    updatePosition();
+    window.addEventListener("resize", updatePosition);
+    window.addEventListener("scroll", updatePosition, true);
+    return () => {
+      window.removeEventListener("resize", updatePosition);
+      window.removeEventListener("scroll", updatePosition, true);
+    };
+  }, [isOpen]);
 
   return (
     <div className="relative flex justify-center">
       <Button
+        ref={buttonRef}
         variant="ghost"
         size="icon-sm"
         onClick={onToggle}
@@ -34,7 +65,10 @@ export function NotePopover({ position, isOpen, onToggle, onClose, onChange }: N
         {hasNote && <span className="absolute right-0.5 top-0.5 h-1.5 w-1.5 rounded-full bg-[var(--tranche-warning)]" />}
       </Button>
       {isOpen && (
-        <div className="absolute right-0 top-10 z-30 w-64 rounded-sm border border-[var(--tranche-border-strong)] bg-[var(--tranche-popover)] p-3 shadow-2xl">
+        <div
+          className="fixed z-50 w-80 rounded-sm border border-[var(--tranche-border-strong)] bg-[var(--tranche-popover)] p-3 shadow-2xl"
+          style={{ top: popoverPosition.top, left: popoverPosition.left }}
+        >
           <div className="mb-2 flex items-center justify-between">
             <p className="text-[10px] font-bold uppercase tracking-[0.12em] text-[var(--tranche-muted)]">
               {position.ticker || "Position"} note

--- a/lib/utils/market-strip.ts
+++ b/lib/utils/market-strip.ts
@@ -29,6 +29,6 @@ export function formatSignedNumber(value: number | null, suffix = "") {
 }
 
 export function getMarketMovementClass(change: number | null) {
-  if (typeof change !== "number") return "text-[var(--tranche-muted-strong)]";
-  return change >= 0 ? "text-[var(--tranche-success)]" : "text-[var(--tranche-danger)]";
+  if (typeof change !== "number") return "market-movement-flat";
+  return change >= 0 ? "market-movement-up" : "market-movement-down";
 }


### PR DESCRIPTION
## Summary
- Render note and ticker popovers as fixed overlays so the allocation table no longer gets vertical scrollbars.
- Brighten allocation table headers and enlarge the delete row button.
- Make market-strip movement values reliably green/red and move the delayed-quotes disclaimer outside the strip flow.

## Verification
- Built production bundle with Next.js.
- Verified note popover does not increase table scroll height.
- Verified market movement values compute green/red in the browser.
